### PR TITLE
feature: RT100747 ignore inline styling hint

### DIFF
--- a/lib/HTML/Hyphenate.pm
+++ b/lib/HTML/Hyphenate.pm
@@ -33,10 +33,7 @@ Readonly::Scalar my $LANG         => q{lang};
 Readonly::Scalar my $TEXT         => q{text};
 Readonly::Scalar my $TAG          => q{tag};
 Readonly::Scalar my $RAW          => q{raw};
-Readonly::Scalar my $NOBR         => q{nobr};
 Readonly::Scalar my $PRE          => q{pre};
-Readonly::Scalar my $NOWRAP       => q{*[nowrap]};
-Readonly::Scalar my $STYLE        => q{style};
 Readonly::Scalar my $CLASS        => q{class};
 Readonly::Scalar my $CLASS_JOINER => q{, .};
 
@@ -59,9 +56,6 @@ Readonly::Scalar my $LOG_REGISTER =>
 # HTML5 %Text attributes <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes>
 my $text_attr =
   Set::Scalar->new(qw/abbr alt label list placeholder standby summary title/);
-
-# Match inline style requesting not to wrap anyway:
-my $STYLE_NOWRAP = q{[style*=nowrap]};
 
 Log::Log4perl->easy_init($ERROR);
 my $log = get_logger();
@@ -238,10 +232,7 @@ sub _hyphenable_by_class {
 
 sub _hyphenable {
     my ( $self, $node ) = @_;
-    return !( $node->ancestors($NOBR)->size
-        || $node->ancestors($PRE)->size
-        || $node->ancestors($NOWRAP)->size
-        || $node->ancestors($STYLE_NOWRAP)->size
+    return !( $node->ancestors($PRE)->size
         || !$self->_hyphenable_by_class($node) );
 }
 

--- a/t/01_default.t
+++ b/t/01_default.t
@@ -56,12 +56,12 @@ my @fragments = (
     ],
     [
         '<p><nobr>Supercalifragilisticexpialidocious</nobr></p>',
-        '<p><nobr>Supercalifragilisticexpialidocious</nobr></p>',
+        '<p><nobr>Su­per­cal­ifrag­ilis­tic­ex­pi­ali­do­cious</nobr></p>',
         'single word pararaph with nobr'
     ],
     [
         '<p style="white-space: nowrap">Supercalifragilisticexpialidocious</p>',
-        '<p style="white-space: nowrap">Supercalifragilisticexpialidocious</p>',
+        '<p style="white-space: nowrap">Su­per­cal­ifrag­ilis­tic­ex­pi­ali­do­cious</p>',
         'single word pararaph with nowrap inline style'
     ],
     [
@@ -76,7 +76,7 @@ my @fragments = (
     ],
     [
 '<table><tr><th nowrap>Supercalifragilisticexpialidocious</th></tr></table>',
-'<table><tr><th nowrap>Supercalifragilisticexpialidocious</th></tr></table>',
+'<table><tr><th nowrap>Su­per­cal­ifrag­ilis­tic­ex­pi­ali­do­cious</th></tr></table>',
         'single word table head with nowrap attribute'
     ],
     [


### PR DESCRIPTION
No longer check for inline styling hints like <nobr> elements, 'nowrap'
attributes or inline style attributes setting the 'whitespace' property
to optimise the process of adding hyphens to a tree. This introduces a
suboptimal situation, but does not break the end-user experience since
it only adds soft hyphens to element that don't use them as far as the
parsed tree is concerned. But this does allow to override the default
behavior of the tree with external styles that could take advantage of
the available soft hyphens.