### PR TITLE
chore: RT100704 update warn tests

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,7 +12,7 @@ Module::Build->new(
         'Readonly'             => 1.03,
         'Set::Scalar'          => 0,
         'TeX::Hyphen'          => 0,
-        'TeX::Hyphen::Pattern' => 0,
+        'TeX::Hyphen::Pattern' => 0.100,
         'Moose'                => 0,
         'namespace::autoclean' => 0,
     },

--- a/lib/HTML/Hyphenate.pm
+++ b/lib/HTML/Hyphenate.pm
@@ -14,7 +14,7 @@ use charnames qw(:full);
 use Log::Log4perl qw(:easy get_logger);
 use Set::Scalar;
 use TeX::Hyphen;
-use TeX::Hyphen::Pattern;
+use TeX::Hyphen::Pattern 0.100;
 use Mojo::DOM;
 
 use Readonly;

--- a/t/03_lang.t
+++ b/t/03_lang.t
@@ -336,7 +336,7 @@ my @utf8_fragments = (
     ],
 );
 # 50 fragments + 14 utf8 fragments
-plan tests => ( 0 + @fragments + (@utf8_fragments << 1)) + 1;
+plan tests => ( 0 + @fragments + @utf8_fragments ) + 1;
 
 use HTML::Hyphenate;
 my $h = HTML::Hyphenate->new();
@@ -347,11 +347,7 @@ foreach my $frag (@fragments) {
 TODO: {
 	local $TODO = q{utf8 patterns not yet supported by TeX::Hyphen};
 	foreach my $frag (@utf8_fragments) {
-		warnings_like {
-			is( $h->hyphenated( @{$frag}[0] ), @{$frag}[1], @{$frag}[2] );
-		} [
-			qr/Use of uninitialized value within %CARON_MAP in substitution iterator.*/,
-		], 'Warned about uninitialized value within %CARON_MAP';
+		is( $h->hyphenated( @{$frag}[0] ), @{$frag}[1], @{$frag}[2] );
 	}
 };
 


### PR DESCRIPTION
No longer catch the warning about the %CARON_MAP in the tests.